### PR TITLE
add nef (nikon raw format) by converting it to webp using imagemagick

### DIFF
--- a/preview
+++ b/preview
@@ -80,11 +80,16 @@ case "$(printf "%s\n" "$(readlink -f "$1")" | awk '{print tolower($0)}')" in
 	*.bmp|*.jpg|*.jpeg|*.png|*.xpm|*.webp|*.tiff|*.gif|*.jfif|*.ico)
 		image "$1" "$2" "$3" "$4" "$5"
 		;;
-  *.svg)
-    [ ! -f "${CACHE}.jpg" ] && \
-      convert "$1" "${CACHE}.jpg"
-    image "${CACHE}.jpg" "$2" "$3" "$4" "$5"
-    ;;
+    *.svg)
+        [ ! -f "${CACHE}.jpg" ] && \
+            convert "$1" "${CACHE}.jpg"
+        image "${CACHE}.jpg" "$2" "$3" "$4" "$5"
+        ;;
+    *.nef)
+		[ ! -f "${CACHE}.webp" ] && \
+            convert "$1" -depth 8 -auto-orient -resize x600 "${CACHE}.webp"
+		image "${CACHE}.webp" "$2" "$3" "$4" "$5"
+        ;;
 	*.ino)
 		batorcat --language=cpp "$1"
 		;;


### PR DESCRIPTION
Add a  new case clause in `preview` to handle .nef files -- i.e. the raw image format for Nikon cameras.
Converts the .nef to webp while resizing to x600 and observing rotation in exif data.