### PR TITLE
Suggest stand alone comicthumb instead of mcomix

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The following packages are optional but if installed will provide more functiona
 * exiftool (optional - for music files)
 * iso-info (optional - for .iso files)
 * transmission (optional - for .torrent files)
-* mcomix (optional - for .cbz and .cbr files)
+* [comicthumb](https://codeberg.org/johndovern/comicthumb) (optional - for .cbz and .cbr files)
 
 ## Installation
 The preferred way of installing lfimg is running make:


### PR DESCRIPTION
Mcomix no longer packages the comicthumb utility in the latest version, 3.1.0. I've yanked out the older python2 comicthumb from the original comix project and have it running on python3 with pillow as the only dependency. I've packaged it as an [AUR package](https://aur.archlinux.org/packages/comicthumb) for Arch users, but anyone can install it with [pip](https://pypi.org/project/comicthumb/).